### PR TITLE
Add a function to log hardware events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ serde_derive="^1"
 itertools="^0"
 rand="^0"
 libc="^0.2"
+x86="*"
+perfcnt="*"
 # thread_binder={version="*", optional=true}
 thread_binder={git="https://github.com/wagnerf42/thread_binder", optional=true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ debug = true
 [features]
 # enable this to bind using thread_binder
 bind = ["thread_binder"]
+perf = ["perfcnt", "x86"]
 
 [target.bind.dependencies]
 thread_binder={git="https://github.com/wagnerf42/thread_binder", optional=true}
@@ -30,8 +31,8 @@ serde_derive="^1"
 itertools="^0"
 rand="^0"
 libc="^0.2"
-x86="*"
-perfcnt="*"
+x86={version="*", optional=true}
+perfcnt={version="*", optional=true}
 # thread_binder={version="*", optional=true}
 thread_binder={git="https://github.com/wagnerf42/thread_binder", optional=true}
 

--- a/examples/manual_max.rs
+++ b/examples/manual_max.rs
@@ -1,9 +1,15 @@
 //! Example for recursive max and tagging of leaves tasks.
-use rayon_logs::{join, subgraph, ThreadPoolBuilder};
+use rayon_logs::prelude::*;
+use rayon_logs::{join, subgraph_perf, ThreadPoolBuilder};
 
 fn manual_max(slice: &[u32]) -> u32 {
     if slice.len() < 200_000 {
-        subgraph("max", slice.len(), || slice.iter().max().cloned().unwrap())
+        subgraph_perf(
+            "max",
+            HardwareEventType::CacheMisses,
+            "Cache Misses",
+            || slice.iter().max().cloned().unwrap(),
+        )
     } else {
         let middle = slice.len() / 2;
         let (left, right) = slice.split_at(middle);

--- a/examples/manual_max_perf_subgraph.rs
+++ b/examples/manual_max_perf_subgraph.rs
@@ -1,0 +1,35 @@
+//! Example for recursive max and tagging of leaves tasks.
+use rayon_logs::prelude::*;
+use rayon_logs::{join, subgraph_perf, ThreadPoolBuilder};
+
+fn manual_max(slice: &[u32]) -> u32 {
+    if slice.len() < 200_000 {
+        subgraph_perf(
+            "max",
+            HardwareEventType::CacheMisses,
+            "Cache Misses",
+            || slice.iter().max().cloned().unwrap(),
+        )
+    } else {
+        let middle = slice.len() / 2;
+        let (left, right) = slice.split_at(middle);
+        let (mleft, mright) = join(|| manual_max(left), || manual_max(right));
+        std::cmp::max(mleft, mright)
+    }
+}
+
+fn main() {
+    let v: Vec<u32> = (0..2_000_000).collect();
+
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(2)
+        .build()
+        .expect("building pool failed");
+    let (max, log) = pool.logging_install(|| manual_max(&v));
+    assert_eq!(max, v.last().cloned().unwrap());
+
+    log.save_svg("manual_max.svg")
+        .expect("saving svg file failed");
+    println!("saved \"manual_max.svg\"");
+    println!("hover mouse over tasks to get logged information !");
+}

--- a/examples/manual_max_perf_subgraph.rs
+++ b/examples/manual_max_perf_subgraph.rs
@@ -1,10 +1,10 @@
 //! Example for recursive max and tagging of leaves tasks.
 use rayon_logs::prelude::*;
-use rayon_logs::{join, subgraph_perf, ThreadPoolBuilder};
+use rayon_logs::{join, subgraph_perf_hw, ThreadPoolBuilder};
 
 fn manual_max(slice: &[u32]) -> u32 {
     if slice.len() < 200_000 {
-        subgraph_perf(
+        subgraph_perf_hw(
             "max",
             HardwareEventType::CacheMisses,
             "Cache Misses",

--- a/src/fork_join_graph.rs
+++ b/src/fork_join_graph.rs
@@ -384,6 +384,9 @@ fn generate_visualisation(
                 WorkInformation::SubgraphEndWork(work_type) => {
                     format!(" end of a subgraph: {}\n", tags[work_type])
                 }
+                WorkInformation::SubgraphPerfWork((work_type, _, _)) => {
+                    format!(" type: {}\n", tags[work_type])
+                }
                 _ => String::new(),
             };
             scene.labels.push(format!(

--- a/src/fork_join_graph.rs
+++ b/src/fork_join_graph.rs
@@ -366,6 +366,9 @@ fn generate_visualisation(
                 WorkInformation::SubgraphStartWork((_, work_amount)) => {
                     format!(" work: {},\n", work_amount)
                 }
+                WorkInformation::SubgraphPerfWork((_, cache_misses, perf_index)) => {
+                    format!(" {}: {},\n", tags[perf_index], cache_misses)
+                }
                 _ => String::new(),
             };
             let type_label = match t.work {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,9 @@ mod pool; // this comes first because it exports the logs macro
 mod iterator;
 mod storage;
 pub use crate::iterator::Logged;
-pub use crate::pool::{join, join_context, subgraph, subgraph_perf, ThreadPool};
+#[cfg(feature = "perf")]
+pub use crate::pool::subgraph_perf;
+pub use crate::pool::{join, join_context, subgraph, ThreadPool};
 mod builder;
 pub mod prelude;
 pub use crate::builder::ThreadPoolBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,9 +290,9 @@ mod pool; // this comes first because it exports the logs macro
 mod iterator;
 mod storage;
 pub use crate::iterator::Logged;
-#[cfg(feature = "perf")]
-pub use crate::pool::subgraph_perf;
 pub use crate::pool::{join, join_context, subgraph, ThreadPool};
+#[cfg(feature = "perf")]
+pub use crate::pool::{subgraph_perf_cache, subgraph_perf_hw, subgraph_perf_sw};
 mod builder;
 pub mod prelude;
 pub use crate::builder::ThreadPoolBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ mod pool; // this comes first because it exports the logs macro
 mod iterator;
 mod storage;
 pub use crate::iterator::Logged;
-pub use crate::pool::{join, join_context, subgraph, ThreadPool};
+pub use crate::pool::{join, join_context, subgraph, subgraph_perf, ThreadPool};
 mod builder;
 pub mod prelude;
 pub use crate::builder::ThreadPoolBuilder;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,11 +1,15 @@
 //! `LoggedPool` structure for logging raw tasks events.
 #![macro_use]
 
+#[cfg(feature = "perf")]
 extern crate perfcnt;
+#[cfg(feature = "perf")]
 extern crate x86;
-
+#[cfg(feature = "perf")]
 use perfcnt::linux::HardwareEventType;
+#[cfg(feature = "perf")]
 use perfcnt::linux::PerfCounterBuilderLinux;
+#[cfg(feature = "perf")]
 use perfcnt::{AbstractPerfCounter, PerfCounter};
 
 use crate::log::RunLog;
@@ -365,6 +369,7 @@ where
 /// and to use the nightly version of the compiler
 ///
 /// You can give a label to the event you are logging
+#[cfg(feature = "perf")]
 pub fn subgraph_perf<OP, R>(
     work_type: &'static str,
     hardware_event: HardwareEventType,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -400,10 +400,10 @@ where
     pc.start().expect("Can not start the counter");
     let r = op();
     pc.stop().expect("Can not stop the counter");;
-    let cache_misses: usize = pc.read().unwrap() as usize;
+    let perf_counter_result: usize = pc.read().unwrap() as usize;
 
     logs!(
-        RayonEvent::SubgraphPerfEnd(work_type, cache_misses, perf_name),
+        RayonEvent::SubgraphPerfEnd(work_type, perf_counter_result, perf_name),
         RayonEvent::Child(continuation_task_id),
         RayonEvent::TaskEnd(precise_time_ns()),
         // start continuation task
@@ -477,10 +477,10 @@ where
     pc.start().expect("Can not start the counter");
     let r = op();
     pc.stop().expect("Can not stop the counter");;
-    let cache_misses: usize = pc.read().unwrap() as usize;
+    let perf_counter_result: usize = pc.read().unwrap() as usize;
 
     logs!(
-        RayonEvent::SubgraphPerfEnd(work_type, cache_misses, perf_name),
+        RayonEvent::SubgraphPerfEnd(work_type, perf_counter_result, perf_name),
         RayonEvent::Child(continuation_task_id),
         RayonEvent::TaskEnd(precise_time_ns()),
         // start continuation task
@@ -564,10 +564,10 @@ where
     pc.start().expect("Can not start the counter");
     let r = op();
     pc.stop().expect("Can not stop the counter");;
-    let cache_misses: usize = pc.read().unwrap() as usize;
+    let perf_counter_result: usize = pc.read().unwrap() as usize;
 
     logs!(
-        RayonEvent::SubgraphPerfEnd(work_type, cache_misses, perf_name),
+        RayonEvent::SubgraphPerfEnd(work_type, perf_counter_result, perf_name),
         RayonEvent::Child(continuation_task_id),
         RayonEvent::TaskEnd(precise_time_ns()),
         // start continuation task

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -336,18 +336,30 @@ where
 }
 
 /// Same as the subgraph function, but we can log a hardware event
+///
 /// (from: https://github.com/gz/rust-perfcnt)
+///
 /// Events:
-///     * HardwareEventType::CPUCycles
-///     * HardwareEventType::Instructions
-///     * HardwareEventType::CacheReferences
-///     * HardwareEventType::CacheMisses
-///     * HardwareEventType::BranchInstructions
-///     * HardwareEventType::BranchMisses
-///     * HardwareEventType::BusCycles
-///     * HardwareEventType::StalledCyclesFrontend
-///     * HardwareEventType::StalledCyclesBackend
-///     * HardwareEventType::RefCPUCycles
+///
+/// * ```HardwareEventType::CPUCycles```
+///
+/// * ```HardwareEventType::Instructions```
+///
+/// * ```HardwareEventType::CacheReferences```
+///
+/// * ```HardwareEventType::CacheMisses```
+///
+/// * ```HardwareEventType::BranchInstructions```
+///
+/// * ```HardwareEventType::BranchMisses```
+///
+/// * ```HardwareEventType::BusCycles```
+///
+/// * ```HardwareEventType::StalledCyclesFrontend```
+///
+/// * ```HardwareEventType::StalledCyclesBackend```
+///
+/// * ```HardwareEventType::RefCPUCycles```
 ///
 /// You will have to import the rayon_logs prelude to use these events
 /// and to use the nightly version of the compiler

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -121,4 +121,6 @@ impl<'data, I: rayon::prelude::IntoParallelRefMutIterator<'data>> IntoParallelRe
 pub use crate::rayon_algorithms::slice::ParallelSliceMut;
 // For the subgraph_perf function
 #[cfg(feature = "perf")]
-pub use perfcnt::linux::HardwareEventType;
+pub use perfcnt::linux::{
+    CacheId, CacheOpId, CacheOpResultId, HardwareEventType, SoftwareEventType,
+};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -119,3 +119,5 @@ impl<'data, I: rayon::prelude::IntoParallelRefMutIterator<'data>> IntoParallelRe
 }
 
 pub use crate::rayon_algorithms::slice::ParallelSliceMut;
+// For the subgraph_perf function
+pub use perfcnt::linux::HardwareEventType;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -120,4 +120,5 @@ impl<'data, I: rayon::prelude::IntoParallelRefMutIterator<'data>> IntoParallelRe
 
 pub use crate::rayon_algorithms::slice::ParallelSliceMut;
 // For the subgraph_perf function
+#[cfg(feature = "perf")]
 pub use perfcnt::linux::HardwareEventType;

--- a/src/raw_events.rs
+++ b/src/raw_events.rs
@@ -24,6 +24,10 @@ pub(crate) enum RayonEvent {
     SubgraphStart(&'static str, usize),
     /// Tag the end of a subgraph.
     SubgraphEnd(&'static str),
+    /// Tag a subgraph with work type, work amount.
+    SubgraphPerfStart(&'static str),
+    /// Tag the end of a subgraph.
+    SubgraphPerfEnd(&'static str, usize, &'static str),
 }
 
 impl RayonEvent {


### PR DESCRIPTION
This PR introduce the ```subgraph_perf``` function that can be used instead of the classical ```subgraph``` function, in order to log hardware events (Cache misses, Branch misses ...)
